### PR TITLE
kubernetes-operators

### DIFF
--- a/kubernetes-operators/co.yaml
+++ b/kubernetes-operators/co.yaml
@@ -1,0 +1,9 @@
+apiVersion: "otus.homework/v1"
+kind: MySQL
+metadata:
+  name: mysql-db
+spec:
+  image: mysql:latest
+  database: test
+  password: test
+  storage_size: 10G

--- a/kubernetes-operators/cr.yaml
+++ b/kubernetes-operators/cr.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr
+rules:
+- apiGroups: ["otus.homework"]
+  resources: ["mysqls"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "update", "patch", "create"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments/status"]
+  verbs: ["get"]

--- a/kubernetes-operators/crb.yaml
+++ b/kubernetes-operators/crb.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb
+subjects:
+- kind: ServiceAccount
+  name: sa
+  apiGroup: ""
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cr
+  apiGroup: rbac.authorization.k8s.io
+

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  group: otus.homework
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: ["database", "image", "password", "storage_size"]
+              properties:
+                image:
+                  type: string
+                  pattern: '^[a-zA-Z0-9:.]+$'
+                database:
+                  type: string
+                  pattern: '^[a-zA-Z0-9]+$'
+                password:
+                  type: string
+                  pattern: '^[a-zA-Z0-9]+$'
+                storage_size:
+                  type: string
+                  pattern: '^[a-zA-Z0-9]+$'
+  scope: Namespaced
+  names:
+    plural: mysqls
+    kind: MySQL

--- a/kubernetes-operators/deployment.yaml
+++ b/kubernetes-operators/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql-operator
+  template:
+    metadata:
+      labels:
+        app: mysql-operator
+    spec:
+      serviceAccountName: sa
+      containers:
+      - name: mysql-operator
+        image: roflmaoinmysoul/mysql-operator:1.0.0

--- a/kubernetes-operators/sa.yaml
+++ b/kubernetes-operators/sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"


### PR DESCRIPTION
# Выполнено ДЗ №6

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
Созданы манифесты ServiceAccount, ClusterRole и ClusterRoleBinding
Написан манифест для deployment, CRD и CustomOperator
Проверено применение манифестов и их работоспособность
Изменена ClusterRole для ограниченного набора прав для работы ресурсов

## Как запустить проект:
В директории kubernetes-operators выполнить:
kubectl apply -f sa.yaml -f cr.yaml -f crb.yaml
kubectl apply -f deployment.yaml
kubectl apply -f crd.yaml
kubectl apply -f co.yaml

## Как проверить работоспособность:
 kubectl get pods
Проверить наличие пода mysql-db, аналогично проверить наличие svc, pv, pvc
Выполнить kubectl delete -f co.yaml и проверить, что ресурсы удалились
## PR checklist:
 - [ ] Выставлен label с темой домашнего задания


###Вывод команд
```
[root@localhost kubernetes-operators]# kubectl apply -f sa.yaml -f cr.yaml -f crb.yaml
Warning: metadata.annotations[kubernetes.io/enforce-mountable-secrets]: deprecated in v1.32+; prefer separate namespaces to isolate access to mounted secrets
serviceaccount/sa created
clusterrole.rbac.authorization.k8s.io/cr created
clusterrolebinding.rbac.authorization.k8s.io/crb created
[root@localhost kubernetes-operators]# kubectl apply -f deployment.yaml
deployment.apps/mysql-operator created
[root@localhost kubernetes-operators]# kubectl apply -f crd.yaml
customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created
[root@localhost kubernetes-operators]# kubectl apply -f co.yaml
mysql.otus.homework/mysql-db created
[root@localhost kubernetes-operators]# kubectl get pods
NAME                              READY   STATUS    RESTARTS   AGE
mysql-db-6ffb9f58c9-z9x69         1/1     Running   0          2m36s
mysql-operator-64869d9dc6-j6pr4   1/1     Running   0          5m27s
[root@localhost kubernetes-operators]# kubectl get svc
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP    6m22s
mysql-db     ClusterIP   None         <none>        3306/TCP   2m41s
[root@localhost kubernetes-operators]# kubectl get pvc
NAME           STATUS   VOLUME        CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
mysql-db-pvc   Bound    mysql-db-pv   10G        RWO            standard       <unset>                 2m46s
[root@localhost kubernetes-operators]# kubectl get pv
NAME          CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
mysql-db-pv   10G        RWO            Retain           Bound    default/mysql-db-pvc   standard       <unset>                          2m47s
[root@localhost kubernetes-operators]# kubectl get mysqls
NAME       AGE
mysql-db   3m12s
[root@localhost kubernetes-operators]# kubectl delete -f co.yaml
mysql.otus.homework "mysql-db" deleted
[root@localhost kubernetes-operators]# kubectl get mysqls
No resources found in default namespace.
[root@localhost kubernetes-operators]# kubectl get pods
NAME                              READY   STATUS    RESTARTS   AGE
mysql-operator-64869d9dc6-j6pr4   1/1     Running   0          6m32s
[root@localhost kubernetes-operators]# kubectl get svc
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   7m28s
[root@localhost kubernetes-operators]# kubectl get pvc
No resources found in default namespace.
[root@localhost kubernetes-operators]# kubectl get pv
No resources found
```